### PR TITLE
Fetch `/ridi/token` with credentials

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: node_js
 node_js:
-  - 'node'
+  - '9'
 
 cache: yarn
 script:

--- a/src/utils/request.js
+++ b/src/utils/request.js
@@ -20,7 +20,7 @@ const getAccountDomain = memoize(() => {
 }, () => 'account-domain');
 
 export const getExpiresIn = async () => {
-  const response = await fetch(`https://account.${getAccountDomain()}/ridi/token/`, { method: 'POST' });
+  const response = await fetch(`https://account.${getAccountDomain()}/ridi/token/`, { method: 'POST', credentials: 'include' });
   const data = await response.json();
   return data.expires_in;
 };


### PR DESCRIPTION
웹뷰어에서 테스트중에 발견한 문제인데요.
이미 로그인을 한 상태인데도 불구하고 POST `/ridi/token` 요청을 보낼때 쿠키를 함께 보내지 않습니다.

[여기](https://developer.mozilla.org/ko/docs/Web/API/Fetch_API/Fetch%EC%9D%98_%EC%82%AC%EC%9A%A9%EB%B2%95)에서 찾아보니 `보통 fetch는 쿠키를 보내거나 받지 않습니다.  사이트에서 사용자 세션을 유지 관리해야하는 경우 인증되지 않는 요청이 발생합니다. 쿠키를 전송하기 위해서는 자격증명(credentials) 옵션을 반드시 설정해야 합니다.` 라고 하는데요. 

한번 검토 부탁드릴게요.


---
**쿠키는 존재**
<img width="1102" alt="2018-04-27 5 15 33" src="https://user-images.githubusercontent.com/8926395/39352567-1840fbfa-4a40-11e8-94f3-132ea60bd5ad.png">

**요청에 cookie가 포함되지 않음**
<img width="622" alt="2018-04-27 5 26 59" src="https://user-images.githubusercontent.com/8926395/39352641-4ba99aec-4a40-11e8-89bf-c1fb0220fb32.png">
